### PR TITLE
Fix LevelPreviewMenu bug

### DIFF
--- a/Assets/Scripts/LevelPreview/LPPlayer.cs
+++ b/Assets/Scripts/LevelPreview/LPPlayer.cs
@@ -98,9 +98,7 @@ public class LPPlayer : MonoBehaviour
     public static void FireSwapToLevel(string sceneName) { SwapToLevel(sceneName); }
 
     public void Awake() {
-        if (Instance == null) {
-            Instance = this;
-        }
+        Instance = this;
     }
 
     public void Start() {

--- a/Assets/Scripts/LevelPreview/LevelPreviewMenuManager.cs
+++ b/Assets/Scripts/LevelPreview/LevelPreviewMenuManager.cs
@@ -46,6 +46,8 @@ public class LevelPreviewMenuManager : MonoBehaviour
     }
 
     public void Start() {
+        Time.timeScale = 1;
+
         LPPlayer.Instance.CurrentNode = FirstNode;
         LevelText.text = "";
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -120,6 +120,9 @@ public class Player : MonoBehaviour
 
     void Update()
     {
+        // Kill the player if a keybind is pressed
+        if (Application.isEditor && Input.GetKey(KeyCode.B) && Input.GetKey(KeyCode.L))
+            GetComponent<PlayerHealth>().decreaseHealth(2 << 28); // is she hurt enough?
 
         Vector2 input = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical")).normalized;
 

--- a/Assets/Scripts/PlayerDeath.cs
+++ b/Assets/Scripts/PlayerDeath.cs
@@ -16,13 +16,16 @@ public class PlayerDeath : MonoBehaviour
     {
         LoadObjects();
     }
+    
+    bool gameOvered = false;
     private void Update()
     {
-        if (health.isDead)
+        if (health.isDead && !gameOvered)
         {
             if (gameOver != null)
             {
                 gameOver.DoGameOver();
+                gameOvered = true;
             }
         }
     }


### PR DESCRIPTION
fix #211 

`Time.timeScale` was set to zero for some reason. I added a little bit of code in `PlayerDeath.cs` to fix that.

Pressing B and L while playing the game will now cause the player to die (only in the editor).