### PR TITLE
improvements

### DIFF
--- a/Assets/Audio/Music/Music_defeatedtheme_SG.wav.meta
+++ b/Assets/Audio/Music/Music_defeatedtheme_SG.wav.meta
@@ -1,0 +1,23 @@
+fileFormatVersion: 2
+guid: e97e21d0632d2cc0f93dcd4026d787de
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 7
+  defaultSettings:
+    serializedVersion: 2
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+    preloadAudioData: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/InGameUI.prefab
+++ b/Assets/Prefabs/InGameUI.prefab
@@ -1065,7 +1065,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3025612703493828312}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
@@ -1168,7 +1168,7 @@ GameObject:
   - component: {fileID: 1783851247669087625}
   - component: {fileID: 5807242416080706054}
   m_Layer: 5
-  m_Name: Passives
+  m_Name: Weapons
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1342,7 +1342,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4013671757366412471}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
   m_Name: 
@@ -1776,8 +1776,8 @@ MonoBehaviour:
   hpBarMask: {fileID: 6179688854667860168}
   xpBarMask: {fileID: 8479832374797907315}
   xpBarText: {fileID: 944193160481391964}
-  weapons: {fileID: 6047162279694182421}
-  passives: {fileID: 1783851247669087625}
+  weapons: {fileID: 1783851247669087625}
+  passives: {fileID: 6047162279694182421}
   twirlParent: {fileID: 2763396321500020495}
   twirlFilledImage: {fileID: 21300000, guid: f5f4aab5cb1f97843930871c29ecfade, type: 3}
   twirlEmptyImage: {fileID: 21300000, guid: d868774db1d136849872258def7d3e67, type: 3}
@@ -2406,7 +2406,7 @@ GameObject:
   - component: {fileID: 6047162279694182421}
   - component: {fileID: 2048493111124289791}
   m_Layer: 5
-  m_Name: Weapons
+  m_Name: Passives
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Resources/Sounds/Music/DeathMusic.asset
+++ b/Assets/Resources/Sounds/Music/DeathMusic.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 68cff8a68a791994698281d8d8db14fe, type: 3}
+  m_Name: DeathMusic
+  m_EditorClassIdentifier: 
+  audioVariants: []
+  volume: 1
+  volumeVariance: 0.1
+  pitch: 1
+  pitchVariance: 0.1
+  minimumDistance: 10
+  loop: 0
+  mixerGroup: {fileID: 0}
+  source: {fileID: 0}

--- a/Assets/Resources/Sounds/Music/DeathMusic.asset.meta
+++ b/Assets/Resources/Sounds/Music/DeathMusic.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e73a90831b2ab1637a3e02f5f8238b2f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BossSceneManager.cs
+++ b/Assets/Scripts/BossSceneManager.cs
@@ -7,6 +7,27 @@ using UnityEngine;
 /// </summary>
 public class BossSceneManager : MonoBehaviour
 {
+    public static bool InBossScene = false;
+
+    // There is a boss, but the health has been disabled.
+    public static bool InPreDialogue { 
+        get => !FindObjectOfType<BossHealth>()?.enabled ?? false;
+    }
+
+    // There is a boss and the health has been enabled.
+    public static bool InBossFight {
+        get => FindObjectOfType<BossHealth>()?.enabled ?? false;
+    }
+
+    // There is no boss and we're in a boss scene.
+    // WARN: if boss death animations are implemented, this function should be double checked.
+    public static bool InPostDialogue {
+        get => FindObjectOfType<BossHealth>() == null && InBossScene;
+    }
+
+    void Awake() { InBossScene = true; }
+    void OnDestroy() { InBossScene = false; }
+
     void Start()
     {
         EquipmentManager.instance.Thaw();

--- a/Assets/Scripts/Enemy/BossHealth.cs
+++ b/Assets/Scripts/Enemy/BossHealth.cs
@@ -51,7 +51,7 @@ public class BossHealth : MonoBehaviour
         // destroy the boss
         // todo: add support for animations
         this.gameObject.SetActive(false);
-        
+
         // trigger post-boss dialogue
         postBossDialogue.gameObject.SetActive(true);
     }

--- a/Assets/Scripts/Equipment/EquipmentManager.cs
+++ b/Assets/Scripts/Equipment/EquipmentManager.cs
@@ -13,7 +13,7 @@ public class EquipmentManager : MonoBehaviour
 {
     // constants
     const int MAX_WEAPONS = 7;
-    const int MAX_PASSIVES = 7;
+    const int MAX_PASSIVES = 5;
     const int MAX_EQUIPMENT_LEVELS = 7;
     
     
@@ -44,11 +44,11 @@ public class EquipmentManager : MonoBehaviour
         ProjectileWeapon.staticStatModifiers = new();
     }
 
-    // NOTE: Thaw needs to happen after Player.Awake and before InGameUI.Start (ie GetUpgradeOptions(true))
+    bool thawed = false;
     /// <summary>
     /// Restores weapons between scene changes / disk. This should only be called once.
     /// </summary>
-    bool thawed = false;
+    // NOTE: Thaw needs to happen after Player.Awake and before InGameUI.Start (ie GetUpgradeOptions(true))
     public void Thaw() {
         if (thawed) { 
             Debug.LogWarning("EquipmentManager.Thaw called more than once!");
@@ -102,15 +102,13 @@ public class EquipmentManager : MonoBehaviour
 
         foreach (var equipment in allEquipment)
         {
-            // enforce first show rules and max weapon and max passive count
-            if (equipment is Weapon && weaponCount >= MAX_WEAPONS) continue;
+            // enforce first show rules 
             if (equipment is Weapon)
                 if (!(equipment as Weapon).availableAtStart && firstShow)
                     continue;
             if (equipment is Passive)
             {
                 if (firstShow) continue;
-                if (passiveCount >= MAX_PASSIVES) continue;
             }
 
             var icon = equipment.icon;
@@ -130,6 +128,9 @@ public class EquipmentManager : MonoBehaviour
             }
             else // present new equipment
             {
+                // only present new equipment if there's enough space
+                if (equipment is Passive && passiveCount >= MAX_PASSIVES) { continue; }
+                if (equipment is Weapon && weaponCount >= MAX_WEAPONS) { continue; }
                 Action onApply = () => AddNewEquipment(equipment);
                 options.Add(new UpgradeOption(icon.name, icon.icon, icon.description, onApply));
             }

--- a/Assets/Scripts/InGameUI.cs
+++ b/Assets/Scripts/InGameUI.cs
@@ -37,8 +37,8 @@ public class InGameUI : MonoBehaviour
 
     public static void UpdateItems()
     {
-        SetItemList(instance.passives, EquipmentManager.instance.EquippedWeaponIcons());
-        SetItemList(instance.weapons, EquipmentManager.instance.EquippedPassiveIcons());
+        SetItemList(instance.passives, EquipmentManager.instance.EquippedPassiveIcons());
+        SetItemList(instance.weapons, EquipmentManager.instance.EquippedWeaponIcons());
     }
 
     public static void UpdateTwirls(int count)

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -98,7 +98,7 @@ public class Player : MonoBehaviour
 
     // sound names
     string xpPickupSound = "XP_Pickup";
-    string takeDamageSound = "Princess_Damage";
+    public string takeDamageSound { get; private set; } = "Princess_Damage";
     string levelUpSound = "Level_Up";
     string twirlDashSound = "Princess_Dash";
 
@@ -141,6 +141,12 @@ public class Player : MonoBehaviour
         // Kill the player if a keybind is pressed
         if (Application.isEditor && Input.GetKey(KeyCode.B) && Input.GetKey(KeyCode.L))
             GetComponent<PlayerHealth>().decreaseHealth(2 << 28); // is she hurt enough?
+
+        // Almost kill the player if a keybind is pressed
+        if (Application.isEditor && Input.GetKey(KeyCode.B) && Input.GetKey(KeyCode.I)) {
+            var health = GetComponent<PlayerHealth>();
+            health.decreaseHealth(health.tempHealth - 1); // owchie
+        }
 
         Vector2 input = new Vector2(Input.GetAxisRaw("Horizontal"), Input.GetAxisRaw("Vertical")).normalized;
 
@@ -338,7 +344,6 @@ public class Player : MonoBehaviour
     {
         immuneTime = ImmunityTimeBetweenHits;
         GetComponent<PlayerHealth>().decreaseHealth(damage);
-        SoundManager.Instance.PlaySoundGlobal(takeDamageSound);
         //print("oww!");
     }
 }

--- a/Assets/Scripts/PlayerHealth.cs
+++ b/Assets/Scripts/PlayerHealth.cs
@@ -37,7 +37,9 @@ public class PlayerHealth : MonoBehaviour
 
     public void decreaseHealth(float num)
     {
-        if (!invincible) {
+        if (!invincible && !BossSceneManager.InPostDialogue) {
+            SoundManager.Instance.PlaySoundGlobal(Player.instance.takeDamageSound);
+
             tempHealth -= num * damageTakenMultiplier;
             InGameUI.SetHp(tempHealth / maxHealth);
             GetComponent<DamageFlash>().Damage();

--- a/Assets/Scripts/Sound/LevelMusicManager.cs
+++ b/Assets/Scripts/Sound/LevelMusicManager.cs
@@ -5,14 +5,22 @@ using UnityEngine;
 public class LevelMusicManager : MonoBehaviour
 {
     [SerializeField] string levelSong;
+    AudioSource audioSource;
+
+    const string deathSong = "DeathMusic";
 
     private void Start()
     {
         PlayLevelSong();
+
+        Player.instance.GetComponent<PlayerHealth>().PlayerDied += () => {
+            audioSource.Stop();
+            audioSource = SoundManager.Instance.PlaySoundGlobal(deathSong);
+        };
     }
 
     public void PlayLevelSong()
     {
-        SoundManager.Instance.PlaySoundGlobal(levelSong);
+        audioSource = SoundManager.Instance.PlaySoundGlobal(levelSong);
     }
 }


### PR DESCRIPTION
* Add game over music (fix #244)
* Reduce number of passives from 7 to 5 (fix #245)
* Fix in game UI code where passives and weapons were mixed up
* Fixed equipment manager handling of max weapons / max passives
* Player no longer takes damage in post boss cut scene (fix #246)
* BossSceneManager now has properties for querying the boss scene state (`InBossScene`, `InPreDialogue`, `InBossFight`, `InPostDialogue`).