### PR TITLE
Fix hell curse bugs

### DIFF
--- a/Assets/Prefabs/LevelUp/LevelUpMenu.prefab
+++ b/Assets/Prefabs/LevelUp/LevelUpMenu.prefab
@@ -496,7 +496,7 @@ MonoBehaviour:
   subtitle: {fileID: 4151440169990518762}
   iconHolder: {fileID: 4024726319412199285}
   openOnStart: 1
-  hellsCurseStart: 0
+  hellsCurseStart: 1
   currentLevel: 3
   LevelUpTitle: Sparkle On, Princess Starshine!!
   LevelUpSubtitle: 'Choose one:'

--- a/Assets/Scenes/Build Scenes/Level01.unity
+++ b/Assets/Scenes/Build Scenes/Level01.unity
@@ -1383,6 +1383,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7216685152336547931, guid: 94ffe939b2266cb44a4692bbb66302f9, type: 3}
+      propertyPath: hellsCurseStart
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7990254352107752931, guid: 94ffe939b2266cb44a4692bbb66302f9, type: 3}
       propertyPath: m_Name
       value: LevelUpMenu

--- a/Assets/Scripts/Equipment/EquipmentManager.cs
+++ b/Assets/Scripts/Equipment/EquipmentManager.cs
@@ -215,6 +215,7 @@ public class EquipmentManager : MonoBehaviour
         currentEquipment.Remove(equipment);
         equipment.OnUnEquip();
         equipment.enabled = false;
+        equipment.levelUpsDone = 0;
 
         foreach (var prevEquipment in currentEquipment)
         {

--- a/Assets/Scripts/LevelUpUI.cs
+++ b/Assets/Scripts/LevelUpUI.cs
@@ -17,7 +17,6 @@ public class LevelUpUI : MonoBehaviour
     public Transform iconHolder;
     public bool openOnStart = true;
     public bool hellsCurseStart = true;
-    public int currentLevel = 2;
 
     [TextArea] public string LevelUpTitle = "Level Up!\nSparkle On, Princess Starshine!!";
     public string LevelUpSubtitle = "Choose one:";
@@ -51,7 +50,7 @@ public class LevelUpUI : MonoBehaviour
         if (hellsCurseStart) {
             title.text = HellsCurseTitle;
             subtitle.text = HellsCurseSubtitle;
-            ShowOptions(EquipmentManager.instance.GetHellsCurseOptions(currentLevel - 1));
+            ShowOptions(EquipmentManager.instance.GetHellsCurseOptions(SaveManager.SaveData.NextLevel - 1));
         } else {
             title.text = LevelUpTitle;
             subtitle.text = LevelUpSubtitle;


### PR DESCRIPTION
* Fixed bug with Hell's curse not showing between levels; fix #306 
* LevelUpUI now derives the level number from save data for hell's curse
* Hell's curse now resets the level of the unequipped item; fix #301